### PR TITLE
Fix default value for input_text

### DIFF
--- a/click_prompt/core/parameter.py
+++ b/click_prompt/core/parameter.py
@@ -164,5 +164,5 @@ class InputTextParameter(PromptParameter, ABC):
 
     def prompt_for_value(self, ctx: click.core.Context) -> Any:
         return questionary.text(
-            self.prompt, default=str(self.get_default(ctx) or "")
+            self.prompt, default=str(self.get_default(ctx) if self.get_default(ctx) != None else "")
         ).unsafe_ask()


### PR DESCRIPTION
Sorry for another Pull-Request, but the old one contains an error if the default value is '0'
Let me know if and when you publish a new version in PyPi.
Thanks.